### PR TITLE
Remove default interval value

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -14,7 +14,7 @@ function stats(opts) {
   var events = opts.events || allContainers(opts);
   var streams = {};
   var oldDestroy = result.destroy;
-  var interval = opts.statsinterval || 1;
+  var interval = opts.statsinterval
 
   result.setMaxListeners(0);
 


### PR DESCRIPTION
Remove default value here as docker-logentries already passes in a default value or a user specified value.
