### PR TITLE
Fix cpu_percent, when statsinterval > 1 

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -81,8 +81,8 @@ function stats(opts) {
             stats: stats
           })
 
-          previousCpu = cpuSum
-          previousSystem = sysSum
+          previousCpu = stats.cpu_stats.cpu_usage.total_usage
+          previousSystem = stats.cpu_stats.system_cpu_usage
 
           sampleCount = 0
           cpuSum = 0
@@ -98,7 +98,6 @@ function stats(opts) {
   function calculateCPUPercent(statItem, previousCpu, previousSystem) {
     var cpuDelta = statItem.cpu_stats.cpu_usage.total_usage - previousCpu
     var systemDelta = statItem.cpu_stats.system_cpu_usage - previousSystem
-
     var cpuPercent = 0.0
     if (systemDelta > 0.0 && cpuDelta > 0.0) {
       cpuPercent = (cpuDelta * 1.0 / systemDelta) * statItem.cpu_stats.cpu_usage.percpu_usage.length * 100.0

--- a/stats.js
+++ b/stats.js
@@ -101,7 +101,7 @@ function stats(opts) {
 
     var cpuPercent = 0.0
     if (systemDelta > 0.0 && cpuDelta > 0.0) {
-      cpuPercent = (cpuDelta / systemDelta) * statItem.cpu_stats.cpu_usage.percpu_usage.length * 100.0
+      cpuPercent = (cpuDelta * 1.0 / systemDelta) * statItem.cpu_stats.cpu_usage.percpu_usage.length * 100.0
     }
     return cpuPercent
   }


### PR DESCRIPTION
Discoverd a lot of 0 cpu values when statsinterval was > 1.
The reason was a negative delta in cpu - prevCpu
