### PR TITLE
add options to better support large numbers of containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ var opts = {
   statsinterval: 10, // downsample stats. Collect a number of statsinterval logs
                      // and output their mean value
 
+  // the following options help reduce CPU load when there are many
+  // containers, and are meant to be used in conjunction with statsinterval
+  streamMode: true, // if false, pull stats once and then disconnect and wait
+                    // until the next statsinterval
+  containerDelay: 0, // time in ms between container stats requests, when
+                     // streamMode is false
+
   // the following options limit the containers being matched
   // so we can avoid catching logs for unwanted containers
   matchByName: /hello/, // optional

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "node": "*"
   },
   "dependencies": {
+    "async": "^2.0.0-rc.3",
     "docker-allcontainers": "^0.4.0",
     "minimist": "^1.1.1",
     "never-ending-stream": "^1.1.2",

--- a/stats.js
+++ b/stats.js
@@ -32,8 +32,7 @@ function stats(opts) {
       var containerObj = containers[container];
       if (containerObj && containerObj.docker) {
         containerObj.docker.stats({stream:false}, function(err, stream) {
-          if (err) {next (err);}
-          if (stream && stream.pipe) {
+          if (!err && stream && stream.pipe) {
             stream.pipe(through.obj(function(stats, enc, cb) {
               this.push({
                        v: 0,

--- a/stats.js
+++ b/stats.js
@@ -26,7 +26,7 @@ function stats(opts) {
   var statsPullInProgress = false;
 
   function getContainerStats() {
-    if (statsPullInProgress) {return;}
+    // if (statsPullInProgress) {return;}
     statsPullInProgress = true;
     async.eachSeries(Object.keys(containers), function(container, next) {
       var containerObj = containers[container];

--- a/stats.js
+++ b/stats.js
@@ -26,7 +26,7 @@ function stats(opts) {
   var statsPullInProgress = false;
 
   function getContainerStats() {
-    // if (statsPullInProgress) {return;}
+    if (statsPullInProgress) {return;}
     statsPullInProgress = true;
     async.eachSeries(Object.keys(containers), function(container, next) {
       var containerObj = containers[container];
@@ -45,8 +45,8 @@ function stats(opts) {
             })).pipe(result, { end: false });
           }
         });
-        setTimeout(next, containerDelay);
       }
+      setTimeout(next, containerDelay);
     }, function() {
       statsPullInProgress = false;
     });


### PR DESCRIPTION
This is re #6, and I'm mostly opening this for feedback, although we are using it in production this way.

I added a couple options.  Setting streamMode to false makes it pull the stats for all the containers once per stats interval, and doesn't do anything the rest of the time.  You can also space out the requests with the containerDelay option (in milliseconds).

Running the released docker-stats on 2GB 2-core machines with ~100 containers, CPU usage of the docker daemon was really high.  Running the new code with streamMode: false, statsinterval: 60 and containerDelay: 100, CPU usage is nice and low, and it seems that the docker daemon isn't getting overwhelmed anymore (docker ps always returns quickly, and we aren't getting as many random errors removing exited containers, and so on).  Here's a graph of CPU usage, with a pretty consistent number of containers throughout, and you can probably guess when the new code was deployed.

![screen shot 2016-04-12 at 9 30 15 pm](https://cloud.githubusercontent.com/assets/2092553/14480433/0128c612-00f7-11e6-89ba-a9ec3c5f9c44.png)
