### PR TITLE
Don't exclude stats from own container

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -40,13 +40,6 @@ function stats (opts) {
   }
 
   function attachContainer (data, container) {
-    // we are trying to tap into this container
-    // we should not do that, or we might be stuck in
-    // an output loop
-    if (data.id.indexOf(process.env.HOSTNAME) === 0) {
-      return
-    }
-
     var stream = nes(function (cb) {
       container.stats(function (err, stream) {
         cb(err, stream)


### PR DESCRIPTION
Fix for https://github.com/pelger/docker-stats/issues/9 - docker-stats provides metrics for all containers. Regular filters like 'skipByImage' still apply. 
