### PR TITLE
[Fixes #16] Updating pump version to circumvent TypeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "docker-allcontainers": "^0.8.0",
     "minimist": "^1.1.1",
     "never-ending-stream": "^2.0.0",
-    "pump": "^2.0.0",
+    "pump": "^3.0.0",
     "split2": "^2.2.0",
     "through2": "^2.0.1"
   },


### PR DESCRIPTION
Updating pump dependency from `2.0.0` to `3.0.0`.